### PR TITLE
Update SparkFun_RHT03.cpp

### DIFF
--- a/Libraries/Arduino/src/SparkFun_RHT03.cpp
+++ b/Libraries/Arduino/src/SparkFun_RHT03.cpp
@@ -99,6 +99,13 @@ int RHT03::update()
     {
         _humidity = ((uint16_t) dataBytes[HUMIDITY_H] << 8) | dataBytes[HUMIDITY_L];
         _temperature = ((uint16_t) dataBytes[TEMP_H] << 8) | dataBytes[TEMP_L];
+	// mod for negative values
+	bool sign;
+	sign = _temperature & 0x8000;
+	if (sign) {
+		_temperature = -(_temperature & 0x7FFF);
+	}
+	// end of mod
         return 1;
     }
     else


### PR DESCRIPTION
The library does not handle negative temperatures according to the RHT-03 specification. The RHT-03 format is that MSB is a sign indicator, it does not use two's complement.